### PR TITLE
Support for KINGARTS-N1 touch panel

### DIFF
--- a/sonoff/sonoff_template.h
+++ b/sonoff/sonoff_template.h
@@ -274,7 +274,9 @@ enum SupportedModules {
   PS_16_DZ,
   TECKIN_US,
   MANZOKU_EU_4,
-  MAXMODULE };
+  KINGARTS_N1,
+  MAXMODULE
+};
 
 /********************************************************************************************/
 
@@ -537,7 +539,8 @@ const uint8_t kModuleNiceList[MAXMODULE] PROGMEM = {
   AILIGHT,            // Light Bulbs
   PHILIPS,
   WITTY,              // Development Devices
-  WEMOS
+  WEMOS,
+  KINGARTS_N1,
 };
 
 // Default module settings
@@ -1626,7 +1629,28 @@ const mytmplt kModules[MAXMODULE] PROGMEM = {
      0,
      GPIO_USER,        // GPIO16
      0
-  }
+  },
+  { "KingArts N1",     // KingArts N1 : 1-gang Touch Lightswitch (ESP8285) - derived from Sonoff Basic
+     GPIO_KEY1,        // GPIO00 Button
+     GPIO_USER,        // GPIO01 Serial RXD and Optional sensor
+     GPIO_USER,        // GPIO02 Only available on newer Sonoff Basic R2 V1
+     GPIO_USER,        // GPIO03 Serial TXD and Optional sensor
+     GPIO_USER,        // GPIO04 Optional sensor
+     0,                // GPIO05
+                       // GPIO06 (SD_CLK   Flash)
+                       // GPIO07 (SD_DATA0 Flash QIO/DIO/DOUT)
+                       // GPIO08 (SD_DATA1 Flash QIO/DIO/DOUT)
+     0,                // GPIO09 (SD_DATA2 Flash QIO or ESP8285)
+     0,                // GPIO10 (SD_DATA3 Flash QIO or ESP8285)
+                       // GPIO11 (SD_CMD   Flash)
+     GPIO_REL1,        // GPIO12 Relay (0 = Off, 1 = On)
+     GPIO_LED1_INV,    // GPIO13 Blue Led (0 = On, 1 = Off)
+     GPIO_USER,        // GPIO14 Optional sensor
+     0,                // GPIO15
+     0,                // GPIO16
+     0                 // ADC0 Analog input
+  },
+
 };
 
 /*


### PR DESCRIPTION
Module info for KingsArt-N1 : ESP8285 based, single gang touch panel light switch.
 - SonOff basic derivitive