### PR TITLE
Added LED blink patterns and mode blink mode configuration

### DIFF
--- a/sonoff/settings.h
+++ b/sonoff/settings.h
@@ -75,7 +75,7 @@ typedef union {                            // Restricted by MISRA-C Rule 18.4 bu
     uint32_t hass_tele_on_power : 1;       // bit 9 (v6.3.0.13)
     uint32_t sleep_normal : 1;             // bit 10 (v6.3.0.15) - SetOption60 - Enable normal sleep instead of dynamic sleep
     uint32_t button_switch_force_local : 1;// bit 11
-    uint32_t spare12 : 1;
+    uint32_t led_indicator_disable : 1;    // bit 12 - disable use of the status LED
     uint32_t spare13 : 1;
     uint32_t spare14 : 1;
     uint32_t spare15 : 1;

--- a/sonoff/settings.ino
+++ b/sonoff/settings.ino
@@ -437,9 +437,12 @@ void SettingsDefaultSet2(void)
   Settings.poweronstate = APP_POWERON_STATE;
   Settings.blinktime = APP_BLINKTIME;
   Settings.blinkcount = APP_BLINKCOUNT;
-  Settings.ledstate = APP_LEDSTATE;
   Settings.pulse_timer[0] = APP_PULSETIME;
 //  for (byte i = 1; i < MAX_PULSETIMERS; i++) { Settings.pulse_timer[i] = 0; }
+
+  // LED
+  Settings.ledstate = APP_LEDSTATE;
+  Settings.flag3.led_indicator_disable = 0;
 
   // Serial
   Settings.baudrate = APP_BAUDRATE / 1200;

--- a/sonoff/sonoff.h
+++ b/sonoff/sonoff.h
@@ -212,7 +212,40 @@ enum WifiConfigOptions {WIFI_RESTART, WIFI_SMARTCONFIG, WIFI_MANAGER, WIFI_WPSCO
 
 enum SwitchModeOptions {TOGGLE, FOLLOW, FOLLOW_INV, PUSHBUTTON, PUSHBUTTON_INV, PUSHBUTTONHOLD, PUSHBUTTONHOLD_INV, PUSHBUTTON_TOGGLE, MAX_SWITCH_OPTION};
 
-enum LedStateOptions {LED_OFF, LED_POWER, LED_MQTTSUB, LED_POWER_MQTTSUB, LED_MQTTPUB, LED_POWER_MQTTPUB, LED_MQTT, LED_POWER_MQTT, MAX_LED_OPTION};
+enum LedStateOptions {
+  LED_OFF           , // = 0x00,
+  LED_POWER         , // = 0x01,
+  LED_MQTTSUB       , // = 0x02,
+  LED_POWER_MQTTSUB , // = 0x03,
+  LED_MQTTPUB       , // = 0x04,
+  LED_POWER_MQTTPUB , // = 0x05,
+  LED_MQTT          , // = 0x06,
+  LED_POWER_MQTT    , // = 0x07,
+  LED_ON            , // = 0x08,
+  MAX_LED_OPTION    ,
+  MASK_LED_OPTION = 0xFF
+};
+
+enum LEDBlinkMode {
+  LED_BLINKMODE_CONTINUOUS, // blink setup will be repeated forever
+  LED_BLINKMODE_LIMITED,    // blink will operate till blink counter reaches stop state
+  MAX_OPTION_LEDBLINKMODE
+};
+
+enum LEDBlinkPattern {
+  LED_BLINKPATTERN_IDLE     = 0x0F, // bits : 0000 1111
+  LED_BLINKPATTERN_ERROR    = 0xAA, // bits : 1010 1010
+  LED_BLINKPATTERN_WIFIDOWN = 0x15, // bits : 0001 0101
+  LED_BLINKPATTERN_MQTTDOWN = 0x05, // bits : 0000 0101
+  MAX_OPTION_LEDBLINKPATTERN
+};
+
+enum LEDBlinkSpeed {
+  LED_BLINKSPEED_FAST       = 1,  // 250ms
+  LED_BLINKSPEED_NORMAL     = 2,  // 500ms
+  LED_BLINKSPEED_SLOW       = 4,  // 1s
+  MAX_OPTION_LEDBLINKSPEED
+};
 
 enum EmulationOptions {EMUL_NONE, EMUL_WEMO, EMUL_HUE, EMUL_MAX};
 


### PR DESCRIPTION
Added blink patterns for IDLE and known error/status states, pattern play rate also setable
 - idle      : 1s off, 1s on
 - error     : fast (250ms - default) flashes
 - wifi down : 2 short flashes
 - mqtt down : 3 short flashes
Added 'Powered' state LED blinks xor's with blink patterns - so status patterns shown

Added LED status/indicator LED disable option
Changed ledstate ops to use enums and mask flags - still working on figuring out the orig intent of the LED control scheme.